### PR TITLE
Update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .DS_Store
+.idea
+.env

--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ To setup and run the demo:
 2. within `anoncreds-smart-contracts-js`: `npm install`
 3. within `anoncreds-smart-contracts-js`: use hardhat to run a local ledger in a seperate terminal: `npx hardhat node`
 4. within `anoncreds-smart-contracts-js`: use hardhat to deploy the `AnoncredsRegistry` & `EthereumDIDRegistry` contract to the local ledger: `npx hardhat run --network localhost scripts/deploy.ts`
-5. copy the deployed address into the `REGISTRY_WETH_ADDRESS` const of the [anoncreds_eth_registry.rs file](/eth-anoncreds-rust-demo/src/anoncreds_eth_registry.rs)
-6. within `eth-anoncreds-rust-demo`: run the demo!: `cargo run`
+   - Lookup value `Contract address` in the output. You need to provide in the next step as env variable.
+5. within `eth-anoncreds-rust-demo`: run the demo!: `ANONCRED_REGISTRY_ADDRESS=<the_value_from_previous_step> cargo run`

--- a/eth-anoncreds-rust-demo/src/anoncreds_eth_registry.rs
+++ b/eth-anoncreds-rust-demo/src/anoncreds_eth_registry.rs
@@ -30,7 +30,7 @@ pub const REGISTRY_RPC: &str = "http://localhost:8545";
 
 // Address of the `AnoncredsRegistry` smart contract to use
 // (should copy and paste the address value after a hardhat deploy script)
-pub const ANONCRED_REGISTRY_ADDRESS: &str = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512";
+pub const DEFAULT_ANONCRED_REGISTRY_ADDRESS: &str = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512";
 
 pub const ETHR_DID_SUB_METHOD: &str = "gmtest";
 
@@ -59,8 +59,9 @@ pub fn get_read_only_ethers_client() -> Arc<impl Middleware> {
 }
 
 pub fn contract_with_client<T: Middleware>(client: Arc<T>) -> AnoncredsRegistry<T> {
+    let anoncreds_contract_address = env::var("ANONCRED_REGISTRY_ADDRESS").unwrap_or(DEFAULT_ANONCRED_REGISTRY_ADDRESS.to_owned());
     AnoncredsRegistry::new(
-        ANONCRED_REGISTRY_ADDRESS.parse::<Address>().unwrap(),
+        anoncreds_contract_address.parse::<Address>().unwrap(),
         client,
     )
 }


### PR DESCRIPTION
- `REGISTRY_WETH_ADDRESS` constant didn't exist in the file, it was actually renamed to `ANONCRED_REGISTRY_ADDRESS`
- Instead of asking user to modify file, changed to providing the contract value via env variable
- The value seem to be deterministic - not sure what the seed to determine the result contract address are - nevertheless provided default value of `ANONCRED_REGISTRY_ADDRESS` if the env variable is not provided