### PR TITLE
Store status list history in events rather than in contract

### DIFF
--- a/eth-anoncreds-rust-demo/src/anoncreds_eth_registry.rs
+++ b/eth-anoncreds-rust-demo/src/anoncreds_eth_registry.rs
@@ -231,7 +231,10 @@ impl AnoncredsEthRegistry {
             })
             .unwrap();
 
-        let ledger_recorded_timestamp = status_list_update_event.timestamp as u64;
+        let ledger_recorded_timestamp = status_list_update_event
+            .status_list
+            .metadata
+            .block_timestamp as u64;
 
         ledger_recorded_timestamp
     }
@@ -368,7 +371,7 @@ fn construct_anoncreds_status_list_from_ledger_event(
         did.try_into().unwrap(),
         recapacitied_rev_list,
         Some(current_accumulator),
-        Some(ledger_event.timestamp.into()),
+        Some(ledger_event.status_list.metadata.block_timestamp.into()),
     )
     .unwrap()
 }

--- a/eth-anoncreds-rust-demo/src/anoncreds_eth_registry.rs
+++ b/eth-anoncreds-rust-demo/src/anoncreds_eth_registry.rs
@@ -201,10 +201,10 @@ impl AnoncredsEthRegistry {
         let did_identity = full_did_into_did_identity(did);
 
         let ledger_status_list =
-            construct_ledger_status_list_from_anoncreds_data(revocation_status_list);
+            construct_ledger_update_status_list_input_from_anoncreds_data(revocation_status_list);
 
         let tx = contract
-            .add_revocation_registry_status_list_update(
+            .update_revocation_registry_status_list(
                 did_identity,
                 String::from(rev_reg_id),
                 ledger_status_list,
@@ -326,9 +326,9 @@ impl AnoncredsEthRegistry {
 }
 
 // anoncreds type -> Ledger data type
-fn construct_ledger_status_list_from_anoncreds_data(
+fn construct_ledger_update_status_list_input_from_anoncreds_data(
     anoncreds_data: &anoncreds::types::RevocationStatusList,
-) -> anoncreds_registry::RevocationStatusList {
+) -> anoncreds_registry::UpdateRevocationStatusListInput {
     // dismantle the inner parts that we want to upload to the registry
     let revocation_status_list_json: Value = serde_json::to_value(anoncreds_data).unwrap();
     let current_accumulator = revocation_status_list_json
@@ -341,7 +341,7 @@ fn construct_ledger_status_list_from_anoncreds_data(
     let bitvec = serde_revocation_list::deserialize(revocation_list_val).unwrap();
     let serialized_bitvec_revocation_list = serde_json::to_string(&bitvec).unwrap();
 
-    anoncreds_registry::RevocationStatusList {
+    anoncreds_registry::UpdateRevocationStatusListInput {
         revocation_list: serialized_bitvec_revocation_list,
         current_accumulator,
     }

--- a/eth-anoncreds-rust-demo/src/roles.rs
+++ b/eth-anoncreds-rust-demo/src/roles.rs
@@ -322,7 +322,7 @@ impl Issuer {
         .unwrap();
         println!("Issuer: submitting rev list initial entry...");
         let ledger_timestamp = anoncreds_registry
-            .submit_rev_reg_status_update(
+            .submit_rev_reg_status_list_update(
                 signer.clone(),
                 &issuer_did,
                 &rev_reg_def_resource_id.to_id(),
@@ -457,7 +457,7 @@ impl Issuer {
 
         let ledger_timestamp = self
             .anoncreds_registry
-            .submit_rev_reg_status_update(
+            .submit_rev_reg_status_list_update(
                 self.signer.clone(),
                 &self.issuer_did,
                 &self.demo_data.rev_reg_def_resource_id.to_id(),


### PR DESCRIPTION
Previously we were storing the FULL history of statuslists in smart contract data. This was so that clients could look up and find the history of the statuslists at given block timestamps (for purpose of creating NRPs). This is however very expensive overkill, as this is data we are storing for client convenience, the historical data is not actually used in the smart contract code itself (smart contract doesn't care about the history). Whenever this is the case in smart contracts, it's probably time to consider whether tracking past data via `Event`s is more suitable, given Events store data for ALOT less cost, but have the limitation of not being accessible on chain.

From: https://consensys.io/blog/guide-to-events-and-logs-in-ethereum-smart-contracts
> Logs were designed to be a form of storage that costs significantly less gas than contract storage. Logs basically [2] cost 8 gas per byte, whereas contract storage costs 20,000 gas per 32 bytes. Although logs offer gargantuan gas savings, logs are not accessible from any contracts [3].
> Nevertheless, there are use cases for using logs as cheap storage, instead of triggers for the frontend. A suitable example for logs is storing historical data that can be rendered by the frontend.

# What this improves and doesn't
* DOES improve write cost significantly, given less new data is being stored each status list update. Data is still being UPDATED, however, AFAIK the difference in cost between adding and updating data is 4:1.
* DOES NOT improve read optimizations. If I were to speculate, it might be slightly slower, since i'd imagine querying/filtering for past Events is probably more intense of an operation for Ethereum Nodes to handle than what we were previously doing
  * I don't consider this the end of the world, since _most_ of the time the status list being used will be the most current
  * I plan on working on a big read optimization soon by utilizing indexing tools like **The Graph**. These optimizations rely on this Event system being implemented
* DOES improve smart contract readability and reduce complexity. And from what I can tell, this seems to be the more _idiomatic_ way of handling historic data

# Other changes
I also added current and past metadata (`RevocationStatusListUpdateMetadata`) into the actual `RevocationStatusList` structure stored in the contract (and emitted in events). This metadata creates a sort of one-way linked list for statuslist update events. A consumer could walk backwards thru updates by following the metadata. But also it importantly allowed me to add more safety checks/validations to the `updateRevocationRegistryStatusList` method. Particularly we now check that multiple updates to a status list aren't made in the same block, and that the block timestamp only increases with each update.

# Aside
Arguably... all our data could be stored as events... this is worth considering in the future